### PR TITLE
fix Julia 0.7RC2 warnings (all but one in precompile)

### DIFF
--- a/src/DAE/events.jl
+++ b/src/DAE/events.jl
@@ -6,7 +6,7 @@
 #
 
 # Provide functions to handle time and state events in user models.
-
+@static if VERSION >= v"0.7.0-DEV.2005" @eval using Printf end
 
 mutable struct EventHandler
    # Input values for the event functions

--- a/src/DAE/simulationState.jl
+++ b/src/DAE/simulationState.jl
@@ -68,10 +68,16 @@ mutable struct SimulationState
    #jac::Union{SparseMatrixCSC{Float64,Cint},Void}
                                      # Optional sparse Jacobian of DAE: der(f!,y) + cr*der(f!, yp)
                                      # (cr is a constant provided by the integrator)
-   jac::Void
-   #cg::Union{ModiaMath.SparseJacobian.ColumnGroups,Void} # if sparse, column groups of Jacobian jac
-   cg::Void # if sparse, column groups of Jacobian jac
+   @static if VERSION >= v"0.7.0-DEV.2005"
+       jac::Nothing
+       #cg::Union{ModiaMath.SparseJacobian.ColumnGroups,Void} # if sparse, column groups of Jacobian jac
+       cg::Nothing # if sparse, column groups of Jacobian jac
+   else
+       jac::Void
+       #cg::Union{ModiaMath.SparseJacobian.ColumnGroups,Void} # if sparse, column groups of Jacobian jac
+       cg::Void # if sparse, column groups of Jacobian jac
 
+   end
    # Model specific information not used by ModiaMath (can be used as default setting for ModiaMath)
    defaultTolerance::Float64    # default relative integration tolerance
    defaultStartTime::Float64    # default start time
@@ -146,9 +152,16 @@ mutable struct SimulationState
       @assert(hev > 0.0)
       @assert(length(x_errorControl) == length(x_start))
       nx = length(x_start)
-      if typeof(jac) != Void
+      @static if VERSION >= v"0.7.0-DEV.2005"
+       if typeof(jac) != Nothing
          @assert(size(jac,1) == nx)
          @assert(size(jac,2) == nx)
+       end
+      else
+       if typeof(jac) != Void
+         @assert(size(jac,1) == nx)
+         @assert(size(jac,2) == nx)
+       end
       end
       @assert(0.0 <= maxSparsity <= 1.0)
       @assert(defaultTolerance > 0.0)

--- a/src/Frames/rotationMatrix.jl
+++ b/src/Frames/rotationMatrix.jl
@@ -5,6 +5,7 @@
 #   ModiaMath.Frames (ModiaMath/Frames/_module.jl)
 #
 
+@static if VERSION >= v"0.7.0-DEV.2005" @eval using LinearAlgebra end
 """
     const ModiaMath.RotationMatrix = SMatrix{3,3,Float64,9}
 
@@ -30,12 +31,19 @@ const RotationMatrix = SMatrix{3,3,Float64,9}
 
 
 """
+@static if VERSION >= v"0.7.0-DEV.2005"
+    const ModiaMath.NullRotation = ModiaMath.RotationMatrix(Matrix(1.0I, 3, 3))
+else
     const ModiaMath.NullRotation = ModiaMath.RotationMatrix(eye(3))
+end
 
 Constant RotationMatrix that defines no rotation from frame 1 to frame 2.
 """
-const NullRotation = SMatrix{3,3,Float64,9}(eye(3))
-
+@static if VERSION >= v"0.7.0-DEV.2005"
+    const NullRotation = SMatrix{3,3,Float64,9}(Matrix(1.0I, 3, 3))
+else
+    const NullRotation = SMatrix{3,3,Float64,9}(eye(3))
+end
 
 
 """

--- a/src/Logging.jl
+++ b/src/Logging.jl
@@ -13,6 +13,8 @@ Martin Otter, [DLR - Institute of System Dynamics and Control](https://www.dlr.d
 """
 module Logging
 
+@static if VERSION >= v"0.7.0-DEV.2005" @eval using Printf end
+
 export Logger, setLog!, setAllLogCategories!, setLogCategories!
 export isLogStatistics, isLogProgress, isLogInfos, isLogWarnings, isLogEvents
 export logOn!, logOff!, setLogCategories

--- a/src/ModiaMath.jl
+++ b/src/ModiaMath.jl
@@ -2,7 +2,7 @@
 # Copyright 2017-2018, DLR Institute of System Dynamics and Control
 
 
-doc"""
+@doc doc"""
 ModiaMath - Mathematical Utilities for Modia and Modia3D
 
 To define a model use Modia or Modia3D. You can define a model
@@ -146,4 +146,4 @@ using .Variables
 include("ModiaToModiaMath.jl")
 using .ModiaToModiaMath
 
-end # module
+end # module 

--- a/src/ModiaToModiaMath.jl
+++ b/src/ModiaToModiaMath.jl
@@ -167,6 +167,6 @@ function simulate(m::ModiaSimulationModel, t::Vector{Float64};
                          interval=interval, 
                          log=log,
                          KLUorderingChoice = KLUorderingChoice)
-end                   
+end                    
                    
 end

--- a/src/SimulationEngine/_module.jl
+++ b/src/SimulationEngine/_module.jl
@@ -21,6 +21,7 @@ import Sundials
 import ModiaMath
 import ModiaMath.DAE
 using  StaticArrays
+@static if VERSION >= v"0.7.0-DEV.2005" @eval using Printf end
 
 # include code
 # include("IDA_UserData.jl")  # is included within simulate.jl

--- a/src/SimulationEngine/simulate.jl
+++ b/src/SimulationEngine/simulate.jl
@@ -24,7 +24,11 @@ mutable struct IntegratorData
    order::MVector{1,Cint}       # Current order for IDAGetCurrentOrder                
    r::Vector{Sundials.realtype} # Residues vector used in idasol_f function
 
-   ida_mem::Ptr{Void}              # IDA pointer (to access all IDAgetXXX functions)
+   @static if VERSION >= v"0.7.0-DEV.2005"
+      ida_mem::Ptr{Nothing}              # IDA pointer (to access all IDAgetXXX functions)
+   else
+      ida_mem::Ptr{Void}              # IDA pointer (to access all IDAgetXXX functions)
+   end
 
    y::Vector{Sundials.realtype}    # Julia vector of y wrapping y_N_Vector vector
    yp::Vector{Sundials.realtype}   # Julia vector of yp wrapping yp_N_Vector vector

--- a/src/SimulationEngine/sundials_ida_UserData.jl
+++ b/src/SimulationEngine/sundials_ida_UserData.jl
@@ -87,7 +87,11 @@ function idasol_f(t::Sundials.realtype, _y::Sundials.N_Vector, _yp::Sundials.N_V
 end
 
 
-const idasol_fc = cfunction(idasol_f, Cint, (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Ref{IntegratorData}))
+@static if VERSION >= v"0.7.0-DEV.2005"
+    const idasol_fc = @cfunction(idasol_f, Cint, (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Ref{IntegratorData}))
+else
+    const idasol_fc = cfunction(idasol_f, Cint, (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Ref{IntegratorData}))
+end
 
 
 #------- root finding
@@ -103,7 +107,11 @@ function idasol_g(t::Sundials.realtype, y::Sundials.N_Vector, yp::Sundials.N_Vec
    return Cint(0)   # indicates normal return
 end
 
-const idasol_gc = cfunction(idasol_g, Cint, (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Ptr{Sundials.realtype}, Ref{IntegratorData}))
+@static if VERSION >= v"0.7.0-DEV.2005"
+    const idasol_gc = @cfunction(idasol_g, Cint, (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Ptr{Sundials.realtype}, Ref{IntegratorData}))
+else
+    const idasol_gc = cfunction(idasol_g, Cint, (Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Ptr{Sundials.realtype}, Ref{IntegratorData}))
+end
 
 #=
 #-------- Jacobian
@@ -137,8 +145,14 @@ function idasol_sjac(t::Sundials.realtype, c_j::Sundials.realtype, y::Sundials.N
     return Cint(0)   # indicates normal return
 end
 
-const idasol_sjacc = cfunction(idasol_sjac, Int32, (Sundials.realtype, Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Ref{SlsMat},
-                                                    Ref{IntegratorData}, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector))
+
+@static if VERSION >= v"0.7.0-DEV.2005"
+    const idasol_sjacc = @cfunction(idasol_sjac, Int32, (Sundials.realtype, Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Ref{SlsMat},
+                                                         Ref{IntegratorData}, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector))
+else
+    const idasol_sjacc = cfunction(idasol_sjac, Int32, (Sundials.realtype, Sundials.realtype, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector, Ref{SlsMat},
+                                                        Ref{IntegratorData}, Sundials.N_Vector, Sundials.N_Vector, Sundials.N_Vector))
+end
 =#
 
 
@@ -168,6 +182,11 @@ function idasol_ErrHandlerFn(error_code::Cint, IDAmodule::Cstring, IDAfunction::
     nothing
 end
 
-const idasol_ErrHandlerFnc = cfunction(idasol_ErrHandlerFn, Void, (Cint, Cstring, Cstring, Cstring,
-                                                                   Ref{IntegratorData}))
+@static if VERSION >= v"0.7.0-DEV.2005"
+    const idasol_ErrHandlerFnc = @cfunction(idasol_ErrHandlerFn, Nothing, (Cint, Cstring, Cstring, Cstring,
+                                                                       Ref{IntegratorData}))
+else
+    const idasol_ErrHandlerFnc = cfunction(idasol_ErrHandlerFn, Void, (Cint, Cstring, Cstring, Cstring,
+                                                                       Ref{IntegratorData}))
+end
 

--- a/src/Variables/components.jl
+++ b/src/Variables/components.jl
@@ -7,11 +7,20 @@
 
 # Definitions used to construct hierarchical variable name spaces
 
-mutable struct ComponentInternal <: ModiaMath.AbstractComponentInternal
+@static if VERSION >= v"0.7.0-DEV.2005"
+ mutable struct ComponentInternal <: ModiaMath.AbstractComponentInternal
    name::Symbol                                                  # Name of component
-   within::Union{ModiaMath.AbstractComponentWithVariables,Void}  # Component in which component is present (if within==nothing, object is not within a component)
+   within::Union{ModiaMath.AbstractComponentWithVariables, Nothing}  # Component in which component is present (if within==nothing, object is
 
    ComponentInternal(name=NoNameDefined, within=nothing) = new(name, within)
+ end
+else
+ mutable struct ComponentInternal <: ModiaMath.AbstractComponentInternal
+   name::Symbol                                                  # Name of component
+   within::Union{ModiaMath.AbstractComponentWithVariables, Void}  # Component in which component is present (if within==nothing, object is not within a component)
+
+   ComponentInternal(name=NoNameDefined, within=nothing) = new(name, within)
+ end
 end
 
 isInComponent(   internal::ModiaMath.AbstractComponentInternal) = typeof(internal.within) != Void


### PR DESCRIPTION
Should be fine.
What could be improved: 

- white space, in particular indentations
- I decided not to add Compat as dependency; with compat some changes would be cleaner