### PR TITLE
Improve result handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@
 language: julia
 os:
   - linux
-  - osx
+#  - osx
 julia:
   - 1.0
-  - 0.7
+#  - 0.7
   - 0.6
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 #  - osx
 julia:
   - 1.0
-#  - 0.7
+  - 0.7
   - 0.6
 
 notifications:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -46,6 +46,18 @@ instead the instructions
 
 ## Release Notes
 
+### Version 0.2.5
+
+- ModiaMath result handling improved:
+  (a) The result may contain single values (such as parameter J=0.1).
+      When using plot(..) on such a result variable, a constant line is plotted
+      between the first and the last point of the xaxis.
+  (b) New function `ModiaMath.resultTable(result)` to transform the variable information
+      in the result data structure in a DataFrames table that can then be printed.
+  (c) New functions `ModiaMath.closeFigure(figure)` and
+      `ModiaMath.closeAllFigures()` to close a specific figure or close all figures.
+
+
 ### Version 0.2.4
 
 - **Non-backwards compatible change of ModiaMath.plot(..)**:

--- a/examples/Simulate_FreeBodyRotation.jl
+++ b/examples/Simulate_FreeBodyRotation.jl
@@ -2,7 +2,7 @@
 # Copyright 2017-2018, DLR Institute of System Dynamics and Control
 
 """
-    module Simulate_FreeBodyRotation 
+    module Simulate_FreeBodyRotation
 
 Simulate a free body rotation with quaternions:
 
@@ -103,5 +103,9 @@ end
 simulationModel = ModiaMath.SimulationModel(FreeBodyRotation(), stopTime=5.0, tolerance=1e-8)
 result          = ModiaMath.simulate!(simulationModel, log=true)
 ModiaMath.plot(result, [:q, :w, :derw, :tau])
+
+# ModiaMath.print_ModelVariables(simulationModel)
+# println("result variables = ", result)
+
 
 end

--- a/examples/Simulate_Pendulum.jl
+++ b/examples/Simulate_Pendulum.jl
@@ -50,4 +50,7 @@ result = ModiaMath.simulate!(simulationModel; log=true)
 plot(result, [(:phi, :w) :a])
 #plot(result, "r[2]", xAxis="r[1]", figure=2)
 
+# ModiaMath.print_ModelVariables(simulationModel)
+# println("result variables = ", result)
+
 end

--- a/src/ModiaMath.jl
+++ b/src/ModiaMath.jl
@@ -110,7 +110,7 @@ Absolute path of package directory of ModiaMath
 """
 const path = dirname(dirname(@__FILE__))   # Absolute path of package directory
 const Time = Float64   # Prepare for later Integer type of time
-const Version = "0.2.5-dev from 2018-10-07 15:34"
+const Version = "0.2.5-dev from 2018-10-14 17:06"
 
 println(" \nImporting ModiaMath version ", Version)
 

--- a/src/ModiaMath.jl
+++ b/src/ModiaMath.jl
@@ -110,7 +110,7 @@ Absolute path of package directory of ModiaMath
 """
 const path = dirname(dirname(@__FILE__))   # Absolute path of package directory
 const Time = Float64   # Prepare for later Integer type of time
-const Version = "0.2.5-dev from 2018-10-14 17:06"
+const Version = "0.2.5-dev from 2018-10-14 21:12"
 
 println(" \nImporting ModiaMath version ", Version)
 

--- a/src/Result/_module.jl
+++ b/src/Result/_module.jl
@@ -29,14 +29,16 @@ generates the following plot:
 module Result
 
 export getStringDictResult, SymbolDictResult, StringDictResult, ResultWithVariables
-export resultHeading, resultTimeSeries, plot
+export resultHeading, resultTimeSeries, resultTable, plot
 export RawResult, nResults, storeRawResult!
+
 
 
 # using/imports
 import ModiaMath
+import DataFrames
 using  Unitful
-using Requires
+using  Requires
 
 # Constants
 const headingSize = 10

--- a/src/Result/_module.jl
+++ b/src/Result/_module.jl
@@ -31,6 +31,7 @@ module Result
 export getStringDictResult, SymbolDictResult, StringDictResult, ResultWithVariables
 export resultHeading, resultTimeSeries, resultTable, plot
 export RawResult, nResults, storeRawResult!
+export closeFigure, closeAllFigures
 
 
 

--- a/src/Result/plotResult.jl
+++ b/src/Result/plotResult.jl
@@ -87,3 +87,19 @@ plot(result, names::Symbol; heading::AbstractString="", grid::Bool=true, xAxis="
 
 plot(result, names::AbstractVector; heading::AbstractString="", grid::Bool=true, xAxis="time", figure::Int=1, prefix::AbstractString="", reuse::Bool=false, maxLegend::Integer=10) =
     plot(result, reshape(names, length(names), 1); heading=heading, grid=grid, xAxis=string(xAxis), figure=figure, prefix=prefix, reuse=reuse, maxLegend=maxLegend)
+
+
+"""
+    ModiaMath.closeFigure(figure::Int)
+
+Closes figure with figure number `figure`.
+"""
+closeFigure(figure::Int) = nothing
+
+
+"""
+    ModiaMath.closeAllFigures()
+
+Closes all open figures.
+"""
+closeAllFigures() = nothing

--- a/src/Result/plotResult_with_PyPlot.jl
+++ b/src/Result/plotResult_with_PyPlot.jl
@@ -137,3 +137,8 @@ function plot(result, names::AbstractMatrix; heading::AbstractString="", grid::B
         #   PyPlot.subplots_adjust(top=0.88)
     end
 end
+
+closeFigure(figure::Int) = PyPlot.close(figure)
+closeAllFigures()        = PyPlot.close("all")
+
+

--- a/src/Result/result.jl
+++ b/src/Result/result.jl
@@ -177,17 +177,17 @@ println("result variables = ", ModiaMath.resultTable(result))
 
 # Results in
 result variables =
-│ Row │ name   │ elType  │ size   │ unit   │
-│     │ String │ String  │ String │ String │
-├─────┼────────┼─────────┼────────┼────────┤
-│ 1   │ phi    │ Float64 │ (100,) │ rad    │
-│ 2   │ time   │ Float64 │ (100,) │ s      │
+│ Row │ name   │ elType  │ sizeOrValue   │ unit   │
+│     │ String │ String  │ String        │ String │
+├─────┼────────┼─────────┼───────────────┼────────┤
+│ 1   │ phi    │ Float64 │ (100,)        │ rad    │
+│ 2   │ time   │ Float64 │ (100,)        │ s      │
 
 ```
 
 """
 function resultTable(result::StringDictAnyResult)
-    resultTable = DataFrames.DataFrame(name=String[], elType=String[], size=String[], unit=String[])
+    resultTable = DataFrames.DataFrame(name=String[], elType=String[], sizeOrValue=String[], unit=String[])
 
     for key in sort( collect( keys(result) ) )
         value = result[key]
@@ -195,7 +195,7 @@ function resultTable(result::StringDictAnyResult)
         # Determine unit as string (if columns have different units, provide unit per column)
         strippedValue =  ustrip.(value) # Strip units from value
         tvalue = typeof( strippedValue )
-        tsize  = sizeToString( strippedValue )
+        tsize  = ndims(value) > 0 ? sizeToString( strippedValue ) : string( strippedValue )
         if tvalue <: Number
             tunit = string( unit(value) )
         elseif tvalue <: AbstractVector || (tvalue <: AbstractMatrix && size(value,2) == 1)
@@ -305,14 +305,15 @@ end
 
 
 function resultTable(result::ResultWithVariables)
-    resultTable = DataFrames.DataFrame(name=String[], elType=String[], size=String[], unit=String[], info=String[])
+    resultTable = DataFrames.DataFrame(name=String[], elType=String[], sizeOrValue=String[], unit=String[], info=String[])
     series      = result.series
     vars        = result.var
 
     for key in sort( collect( keys(series) ) )
         value = series[key]
         var   = vars[Symbol(key)]
-        push!(resultTable, [key, string( typeof(value[1]) ), sizeToString(value), var.unit, var.info] )
+        tsize = ndims(value) > 0 ? sizeToString( value ) : string( value )
+        push!(resultTable, [key, string( typeof(value[1]) ), tsize, var.unit, var.info] )
     end
     return resultTable
 end

--- a/src/Result/result.jl
+++ b/src/Result/result.jl
@@ -320,7 +320,11 @@ end
 
 
 function Base.show(io::IO, result::ResultWithVariables)
-    show(io, resultTable(result), summary=false, splitcols=true)
+    @static if VERSION >= v"0.7.0-DEV.2005" 
+        show(io, resultTable(result), summary=false, splitcols=true)
+    else
+        show(io, resultTable(result))
+    end
 end
 
 

--- a/src/Variables/modelVariables.jl
+++ b/src/Variables/modelVariables.jl
@@ -528,25 +528,32 @@ end
 
 
 """
-   table = print_ModelVariables(vars::ModelVariables)
+   table = print_ModelVariables(obj)
 
-Print all the variables in `vars` in form of DataFrames tables.
+Print all the variables in `obj` in form of DataFrames tables.
+`obj` can be of type ModiaMath.ModelVariables or ModiaMath.SimulationModel.
 """
 function print_ModelVariables(m::ModelVariables)
     variabletable = ModiaMath.get_variableTable(m.var)
-    println("\n\nvariables: ", variabletable)
-
     x_table = ModiaMath.get_xTable(m)
-    println("\n\nx vector: ", x_table)
-
     copyToVariableTable = ModiaMath.get_copyToVariableTable(m)
-    println("\n\ncopy to variables: ", copyToVariableTable)
-
     copyToResidueTable = ModiaMath.get_copyToResidueTable(m)
-    println("\n\ncopy to residue vector: ", copyToResidueTable)
-
     copyToResultTable = ModiaMath.get_copyToResultTable(m)
-    println("\n\ncopy to results: ", copyToResultTable)
+
+    @static if VERSION < v"0.7.0-DEV.2005"
+        println("\n\nvariables: ", variabletable)
+        println("\n\nx vector: ", x_table)
+        println("\n\ncopy to variables: ", copyToVariableTable)
+        println("\n\ncopy to residue vector: ", copyToResidueTable)
+        println("\n\ncopy to results: ", copyToResultTable)
+    else
+        print("\n\nvariables: ");                show(variabletable      , splitcols=true, summary=false)
+        print("\n\n\nx vector: ");               show(x_table            , splitcols=true, summary=false)
+        print("\n\n\ncopy to variables: ");      show(copyToVariableTable, splitcols=true, summary=false)
+        print("\n\n\ncopy to residue vector: "); show(copyToResidueTable , splitcols=true, summary=false)
+        print("\n\n\ncopy to results: ");        show(copyToResultTable  , splitcols=true, summary=false)
+        print("\n")
+    end
 end
 
 

--- a/src/Variables/simulationModel.jl
+++ b/src/Variables/simulationModel.jl
@@ -56,7 +56,7 @@ mutable struct SimulationModel <: ModiaMath.AbstractSimulationModel
     end
 end 
 
-print_ModelVariables(simulationModel::ModiaMath.AbstractSimulationModel) = print_ModelVariables(simulationModel.var)
+print_ModelVariables(simulationModel::SimulationModel) = print_ModelVariables(simulationModel.var)
 
 getVariableName(model,vcat,vindex) = ModiaMath.DAE.getVariableName(model,vcat,vindex;
                                                                    xNames = model.var.x_names) 

--- a/test/result/test_Plot1.jl
+++ b/test/result/test_Plot1.jl
@@ -27,4 +27,7 @@ ModiaMath.plot(result, :phi, heading="Sine(time)")
 println("... Next plot should give a warning:")
 ModiaMath.plot(result, :SignalNotDefined, heading="Sine(time)", figure=2)
 
+# Print result variables
+println("\n... result variables = ", ModiaMath.resultTable(result))
+
 end

--- a/test/result/test_Plot2.jl
+++ b/test/result/test_Plot2.jl
@@ -39,6 +39,9 @@ ModiaMath.plot(result, "r[2:3]", figure=4)
 println("\n... Next plot should give a warning:")
 ModiaMath.plot(result, "phi", xAxis="r", figure=4)
 
+println("\n... figure=4 is closed")
+ModiaMath.closeFigure(4)
+
 # Print result variables
 println("\n... result variables = ", result)
 

--- a/test/result/test_Plot2.jl
+++ b/test/result/test_Plot2.jl
@@ -39,6 +39,9 @@ ModiaMath.plot(result, "r[2:3]", figure=4)
 println("\n... Next plot should give a warning:")
 ModiaMath.plot(result, "phi", xAxis="r", figure=4)
 
+# Print result variables
+println("\n... result variables = ", result)
+
 
 # Add next simulation run to plot
 result.series["phi"] = 1.2*sin.(t)

--- a/test/result/test_Plot3.jl
+++ b/test/result/test_Plot3.jl
@@ -33,6 +33,11 @@ ModiaMath.plot(result, :phi, xAxis=:w, heading="phi=f(w)", figure=3)
 println("\n... Next plot should give a warning:")
 ModiaMath.plot(result, :phi, xAxis=:xAxisNotDefined, heading="phi=f(w)", figure=4)
 
+# Print result variables
+println("\n... result variables = ", ModiaMath.resultTable(result))
+
+
+
 # Add new simulation result
 result["phi"]  = 1.2*result["phi"]
 result["phi2"] = 1.1*result["phi2"]

--- a/test/result/test_Plot3.jl
+++ b/test/result/test_Plot3.jl
@@ -19,13 +19,16 @@ end
 using ModiaMath.Unitful
 
 result = Dict{AbstractString,Any}()
-result["time"]  = t
-result["phi"]   = sin.(t)u"rad"
-result["phi2"]  = 0.5 * sin.(t)u"rad"
-result["w"]     = cos.(t)u"rad/s"
+result["time"]    = t
+result["phi"]     = sin.(t)u"rad"
+result["phi2"]    = 0.5 * sin.(t)u"rad"
+result["w"]       = cos.(t)u"rad/s"
+result["phi_max"]     = 1.1u"rad"
+result["phi_max_int"] = 1
+result["open"]        = false
 
 println("\n... Next plot should give a warning:")
-ModiaMath.plot(result, (:phi, :phi2, :w, :signalNotDefined), heading="Sine(time)", figure=1)
+ModiaMath.plot(result, (:phi_max, :phi_max_int, :open, :phi, :phi2, :w, :signalNotDefined), heading="Sine(time)", figure=1)
 
 ModiaMath.plot(result, [:phi, :phi2, :w], heading="Sine(time)", figure=2)
 ModiaMath.plot(result, :phi, xAxis=:w, heading="phi=f(w)", figure=3)

--- a/test/result/test_Plot4.jl
+++ b/test/result/test_Plot4.jl
@@ -31,4 +31,7 @@ ModiaMath.plot(result, [ (:phi), (:phi, :phi2, :w), (:w, :w2) ], heading="Vector
 
 ModiaMath.plot(result, [ "r", "r2[3]", "r2"], heading="Vector of plots", figure=2)
 
+# Print result variables
+println("\n... result variables = ", ModiaMath.resultTable(result))
+
 end

--- a/test/result/test_Plot5.jl
+++ b/test/result/test_Plot5.jl
@@ -38,4 +38,6 @@ result = ModiaMath.ResultWithVariables(series, var, "")
 ModiaMath.plot(result, [ (:phi, :r)      (:phi, :phi2, :w);
                          (:w, :w2, :phi2) (:phi, :w)      ], heading="Matrix of plots")
 
+# Print result variables
+println("\n... result variables = ", result)
 end

--- a/test/result/test_Plot6.jl
+++ b/test/result/test_Plot6.jl
@@ -30,4 +30,8 @@ ModiaMath.plot(result, [ (:phi1,)           (:phi2, :w1);
                          (:phi1, :phi2, :w1)  (:w2,)     ], figure=6)   # 4 diagrams in form of a matrix
 ModiaMath.plot(result, :w1, xAxis=:phi1, figure=7)                   # Plot w1=f(phi1) in one diagram
 
+
+# Print result variables
+println("\n... result variables = ", ModiaMath.resultTable(result))
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,11 +11,16 @@ else
     using ModiaMath.Test
 end
 
+import ModiaMath
+
 @testset "Test ModiaMath" begin
     include(joinpath("result", "_includes.jl"))
     include(joinpath("variables", "_includes.jl"))
     include(joinpath("frames", "_includes.jl"))
     include(joinpath("simulation", "_includes.jl"))
+
+    println("\n... close all open figures.")
+    ModiaMath.closeAllFigures()
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 module Runtests
 
+import ModiaMath
 
 @static if VERSION < v"0.7.0-DEV.2005"
     using Base.Test
@@ -11,7 +12,6 @@ else
     using ModiaMath.Test
 end
 
-import ModiaMath
 
 @testset "Test ModiaMath" begin
     include(joinpath("result", "_includes.jl"))

--- a/test/runtestsWithModiaAndModia3D.jl
+++ b/test/runtestsWithModiaAndModia3D.jl
@@ -1,0 +1,9 @@
+module runtestsWithModiaAndModia3D
+
+import Modia
+import Modia3D
+
+include("$(Modia.ModiaDir)/test/runtests.jl")
+include("$(Modia3D.path)/test/runtests.jl")
+
+end

--- a/test/runtestsWithModiaAndModia3D.jl
+++ b/test/runtestsWithModiaAndModia3D.jl
@@ -2,8 +2,26 @@ module runtestsWithModiaAndModia3D
 
 import Modia
 import Modia3D
+import ModiaMath
 
-include("$(Modia.ModiaDir)/test/runtests.jl")
-include("$(Modia3D.path)/test/runtests.jl")
+@static if VERSION < v"0.7.0-DEV.2005"
+    using Base.Test
+else
+    # Desired:
+    #   using Test
+    # 
+    # In order that Test need not to be defined in the user environment, it is included via ModiaMath:
+    using ModiaMath.Test
+end
+
+
+@testset "Test Modia and Modia3D" begin
+    include("$(Modia.ModiaDir)/test/runtests.jl")
+    include("$(Modia3D.path)/test/runtests.jl")
+
+    println("\n... close all open figures.")
+    ModiaMath.closeAllFigures()
+end
+
 
 end


### PR DESCRIPTION
Improve ModiaMath result handling:

- New functions `ModiaMath.closeFigure(figure)` and
   `ModiaMath.closeAllFigures()` to close a specific figure or close all figures.

- The result may contain single values (such as parameter J=0.1).
   When using `plot(..)` on such a result variable, a constant line is plotted
   between the first and the last point of the xaxis.

- New function `ModiaMath.resultTable(result)` to transform the variable information
   in the result data structure in a DataFrames table that can then be printed. Example:
```julia
import ModiaMath
using  Unitful

t = range(0.0, stop=10.0, length=100)
result = Dict{AbstractString,Any}()
result["time"] = t * u"s";
result["phi"]  = sin.(t)u"rad";

# Print table of the variables that are stored in result
println("result variables = ", ModiaMath.resultTable(result))

# Results in
result variables =
│ Row │ name   │ elType  │ sizeOrValue   │ unit   │
│     │ String │ String  │ String        │ String │
├─────┼────────┼─────────┼───────────────┼────────┤
│ 1   │ phi    │ Float64 │ (100,)        │ rad    │
│ 2   │ time   │ Float64 │ (100,)        │ s      │
```


