### PR TITLE
Change PyPlot defaults

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -49,13 +49,18 @@ instead the instructions
 ### Version 0.2.5
 
 - ModiaMath result handling improved:
-  (a) The result may contain single values (such as parameter J=0.1).
-      When using plot(..) on such a result variable, a constant line is plotted
-      between the first and the last point of the xaxis.
-  (b) New function `ModiaMath.resultTable(result)` to transform the variable information
-      in the result data structure in a DataFrames table that can then be printed.
-  (c) New functions `ModiaMath.closeFigure(figure)` and
-      `ModiaMath.closeAllFigures()` to close a specific figure or close all figures.
+  * The result may contain single values (such as parameter J=0.1).
+    When using plot(..) on such a result variable, a constant line is plotted
+    between the first and the last point of the x-axis.
+  * New function `ModiaMath.resultTable(result)` to transform the variable information
+    in the result data structure in a DataFrames table  
+    (containing variable name + type + size ) that can then be printed.
+  * New functions `ModiaMath.closeFigure(figure)` and
+    `ModiaMath.closeAllFigures()` to close a specific figure or close all figures.
+  * Changing some default options of PyPlot. In particular, (a) the labels on the x- and y-axis
+    use exponential notation (e.g. 1e5), if the numbers are larger as 1e3 or smaller as 1e-3
+    (PyPlot default is 1e7 and 1e-7), (b) smaller fonts and linewidth are used.
+    Default options are changed via PyCall. If PyCall is not in the Julia environment, PyCall is added.
 
 
 ### Version 0.2.4
@@ -65,14 +70,14 @@ instead the instructions
   simplify implementation and maintenance and to use the identical dictionary type as in Modia.
 
 - ModiaMath.plot(..) improved:
-  (a) For the dictionary type used by Modia, all elements of a variable vector
-      are plotted by giving the variable name, or one specific element of the variable vector is plotted by giving
-      the name and the vector index.
-  (b) A new keyword argument `maxLegend=10` introduced: If the number of entries in a legend exceeds this number,
-      no legend is included in the plot. Note, the curves can still be identified by clicking in the tool bar of the
-      plot window on button `Edit axis, curve ..`.
-  (c) If the plot function is used in the wrong way (e.g. signals shall be plotted that are not in the result dictionary, or selecting a
-      variable vector as x-axis), warning messages are printed and the call is ignored.
+  * For the dictionary type used by Modia, all elements of a variable vector
+    are plotted by giving the variable name, or one specific element of the variable vector is plotted by giving
+    the name and the vector index.
+  * A new keyword argument `maxLegend=10` introduced: If the number of entries in a legend exceeds this number,
+    no legend is included in the plot. Note, the curves can still be identified by clicking in the tool bar of the
+    plot window on button `Edit axis, curve ..`.
+  * If the plot function is used in the wrong way (e.g. signals shall be plotted that are not in the result dictionary, or selecting a
+    variable vector as x-axis), warning messages are printed and the call is ignored.
 
 - Dependent packages updated to their newest versions.
   Especially, warnings from Unitful do no longer occur, due to the update to version 0.12.0.

--- a/src/ModiaMath.jl
+++ b/src/ModiaMath.jl
@@ -110,7 +110,7 @@ Absolute path of package directory of ModiaMath
 """
 const path = dirname(dirname(@__FILE__))   # Absolute path of package directory
 const Time = Float64   # Prepare for later Integer type of time
-const Version = "0.2.5-dev from 2018-10-14 21:12"
+const Version = "0.2.5-dev from 2018-10-28 08:47"
 
 println(" \nImporting ModiaMath version ", Version)
 

--- a/src/Result/_module.jl
+++ b/src/Result/_module.jl
@@ -59,12 +59,34 @@ include("plotResult_with_Nothing.jl")
 function __init__()
     if !Requires.isprecompiling()  
         @eval Main begin
+            pyplotAvailable = false
             try
                 import PyPlot
+                global pyplotAvailable = true
             catch
                 println("    PyPlot not available (plot commands will be ignored).\n",
                         "    Try to install PyPlot. See hints here:\n",
                         "    https://github.com/ModiaSim/ModiaMath.jl/wiki/Installing-PyPlot-in-a-robust-way.")
+            end
+
+            if pyplotAvailable
+                try
+                    import PyCall
+                catch
+                    println("... From ModiaMath: PyCall is added, since needed to set default options for PyPlot")
+                    import Pkg
+                    Pkg.add("PyCall")
+                    import PyCall       
+                end
+
+                rc = PyCall.PyDict(PyPlot.matplotlib["rcParams"])
+                rc["axes.formatter.limits"] = [-3,3]
+                rc["font.size"]        = 8.0
+                rc["lines.linewidth"]  = 1.0
+                rc["grid.linewidth"]   = 0.5 
+                rc["axes.grid"]        = true
+                rc["axes.titlesize"]   = "medium"
+                rc["figure.titlesize"] = "medium"
             end
         end
     end

--- a/src/Result/plotResult_with_PyPlot.jl
+++ b/src/Result/plotResult_with_PyPlot.jl
@@ -86,7 +86,7 @@ function plot(result, names::AbstractString; heading::AbstractString="", grid::B
     heading2 = getHeading(result, heading)
     
     if heading2 != "" && !reuse
-        PyPlot.title(heading2, size=headingSize)    # Python 2.7: fontsize; Python 3.x: size
+        PyPlot.title(heading2)    # Python 2.7: fontsize; Python 3.x: size
       #PyPlot.suptitle(heading, fontsize=12)
       #PyPlot.tight_layout()
       #PyPlot.subplots_adjust(top=0.88)
@@ -103,7 +103,7 @@ function plot(result, names::Tuple; heading::AbstractString="", grid::Bool=true,
     heading2 = getHeading(result, heading)
     
     if heading2 != "" && !reuse
-        PyPlot.title(heading2, size=headingSize)    # Python 2.7: fontsize; Python 3.x: size
+        PyPlot.title(heading2)    # Python 2.7: fontsize; Python 3.x: size
     end
 end
 
@@ -125,14 +125,14 @@ function plot(result, names::AbstractMatrix; heading::AbstractString="", grid::B
             addPlot(result, names[i,j], grid, xLabel, xAxis2, prefix, reuse, maxLegend)
             k = k + 1
             if ncol == 1 && i == 1 && heading2 != "" && !reuse
-                PyPlot.title(heading2, size=headingSize)
+                PyPlot.title(heading2)
             end
         end
     end
 
     # Add overall heading in case of a matrix of diagrams (ncol > 1)
     if ncol > 1 && heading2 != "" && !reuse
-        PyPlot.suptitle(heading2, size=headingSize)
+        PyPlot.suptitle(heading2)
         #   PyPlot.tight_layout()
         #   PyPlot.subplots_adjust(top=0.88)
     end


### PR DESCRIPTION
When plotting pressure, specific enthalpies etc., the ModiaMath PyPlot plots look not good, because exponential format for the y-axis labels is only used if numbers are > 1e7. Changed the following defaults:
-  the labels on the x- and y-axis use exponential notation (e.g. 1e5), if the numbers are larger as 1e3 or smaller as 1e-3
- smaller font sizes
- smaller linewidth

Default options are changed via PyCall. If PyCall is not in the Julia environment, PyCall is (automatically) added.