### PR TITLE
Convert result data to Float64

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -58,9 +58,14 @@ instead the instructions
   * New functions `ModiaMath.closeFigure(figure)` and
     `ModiaMath.closeAllFigures()` to close a specific figure or close all figures.
   * Changing some default options of PyPlot. In particular, (a) the labels on the x- and y-axis
-    use exponential notation (e.g. 1e5), if the numbers are larger as 1e3 or smaller as 1e-3
+    use exponential notation (e.g. 1e5), if the numbers are larger as 1e4 or smaller as 1e-3
     (PyPlot default is 1e7 and 1e-7), (b) smaller fonts and linewidth are used.
     Default options are changed via PyCall. If PyCall is not in the Julia environment, PyCall is added.
+  * If a vector or matrix of subplots is defined, then the x-axis labels
+    are only displayed for the last subplot row.
+  * Result data is always converted to Float64 before passing it to PyPlot.
+    Therefore, Julia numbers can be plotted, even if the types of the numbers are not supported by PyPlot
+    (for example rational numbers can be plotted).
 
 
 ### Version 0.2.4

--- a/src/ModiaMath.jl
+++ b/src/ModiaMath.jl
@@ -59,6 +59,19 @@ For more information, see (https://github.com/ModiaSim/ModiaMath.jl/blob/master/
 """
 module ModiaMath
 
+"""
+    const path
+
+Absolute path of package directory of ModiaMath
+"""
+const path = dirname(dirname(@__FILE__))   # Absolute path of package directory
+const Time = Float64   # Prepare for later Integer type of time
+const Version = "0.2.5-dev from 2018-11-03 07:00"
+
+println(" \nImporting ModiaMath version ", Version)
+
+
+
 # Exported symbols
 export @component
 export RealVariable, RealScalar, RealSVector, RealSVector3
@@ -103,16 +116,7 @@ A real [`ModiaMath.AbstractVariable`](@ref) (either scalar or array)
 abstract type AbstractRealVariable <: AbstractVariable end
 
 
-"""
-    const path
 
-Absolute path of package directory of ModiaMath
-"""
-const path = dirname(dirname(@__FILE__))   # Absolute path of package directory
-const Time = Float64   # Prepare for later Integer type of time
-const Version = "0.2.5-dev from 2018-10-28 08:47"
-
-println(" \nImporting ModiaMath version ", Version)
 
 
 getVariableAndResidueValues(extraInfo::Any) = nothing    # Return a variable value and a residue value table of nonlinear solver (for error message)

--- a/src/Result/_module.jl
+++ b/src/Result/_module.jl
@@ -80,7 +80,7 @@ function __init__()
                 end
 
                 rc = PyCall.PyDict(PyPlot.matplotlib["rcParams"])
-                rc["axes.formatter.limits"] = [-3,3]
+                rc["axes.formatter.limits"] = [-3,4]
                 rc["font.size"]        = 8.0
                 rc["lines.linewidth"]  = 1.0
                 rc["grid.linewidth"]   = 0.5 

--- a/src/Result/plotResult.jl
+++ b/src/Result/plotResult.jl
@@ -16,9 +16,12 @@ Units can be either added by using package `Unitful` if result is just a diction
 can be added by using package `ModiaMath.Result`, where units are defined as elements
 of the variable definition. 
 
+
 # Arguments
 Argument `result` maybe one of the following:
-- A dictionary `Dict{AbstractString,Any}`
+- A dictionary `Dict{AbstractString,Any}`. Note, before passing data to the plot package,
+  it is converted to Float64. This allows to, for example, also plot rational numbers,
+  even if not supported by the plot package.
 - An instance of struct [`ModiaMath.Result`](@ref)
 - An object for which function [`ModiaMath.resultTimeSeries`](@ref) is defined.
 

--- a/src/Result/plotResult_with_PyPlot.jl
+++ b/src/Result/plotResult_with_PyPlot.jl
@@ -121,7 +121,11 @@ function plot(result, names::AbstractMatrix; heading::AbstractString="", grid::B
     for i = 1:nrow
         xLabel = i == nrow
         for j = 1:ncol
-            PyPlot.subplot(nrow, ncol, k)
+            ax=PyPlot.subplot(nrow, ncol, k)
+            if !xLabel
+                # Remove xaxis tick labels, if not the last row
+                ax[:set_xticklabels]([])
+            end
             addPlot(result, names[i,j], grid, xLabel, xAxis2, prefix, reuse, maxLegend)
             k = k + 1
             if ncol == 1 && i == 1 && heading2 != "" && !reuse

--- a/src/Result/result.jl
+++ b/src/Result/result.jl
@@ -103,7 +103,7 @@ function resultTimeSeries(result::StringDictAnyResult, name, xLabel::Bool, xAxis
         return (nothing, nothing, nothing, nothing)
     end
     xsigLegend = xLabel ? appendUnit(string(xAxis), string(unit(xsig[1]))) : ""
-    xsig       = ustrip.(xsig)
+    xsig       = convert.(Float64, ustrip.(xsig))
 
 
     # Get y-axis signals
@@ -143,7 +143,7 @@ function resultTimeSeries(result::StringDictAnyResult, name, xLabel::Bool, xAxis
         return (nothing, nothing, nothing, nothing)
     end
 
-    ysig = ustrip.(ysig)
+    ysig = convert.(Float64, ustrip.(ysig))
 
 
     return (xsig, xsigLegend, ysig, ysigLegend)
@@ -193,7 +193,7 @@ function resultTable(result::StringDictAnyResult)
         value = result[key]
 
         # Determine unit as string (if columns have different units, provide unit per column)
-        strippedValue =  ustrip.(value) # Strip units from value
+        strippedValue = ustrip.(value) # Strip units from value
         tvalue = typeof( strippedValue )
         tsize  = ndims(value) > 0 ? sizeToString( strippedValue ) : string( strippedValue )
         if tvalue <: Number


### PR DESCRIPTION
- Result data is converted to Float64 before passing it to PyPlot.  Therefore, Julia numbers can be plotted, even if the types of the numbers are not supported by PyPlot (for example rational numbers can be plotted).  
- If a vector or matrix of subplots is defined, then the x-axis labels are only displayed for the last subplot row.
